### PR TITLE
Add configuration support with tests

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/rohitkeshwani07/go-bootstrap/internal/users"
+	"github.com/rohitkeshwani07/go-bootstrap/pkg/config"
 	"github.com/rohitkeshwani07/go-bootstrap/pkg/router"
 	"github.com/rohitkeshwani07/go-bootstrap/routes"
 	"go.uber.org/fx"
@@ -21,6 +22,7 @@ func main() {
 	fx.New(
 		fx.StopTimeout(MaxTimeGracefullShutdown),
 		fx.Provide(
+			config.LoadConfig,
 			router.NewRouter,
 			routes.NewRoutes,
 			users.NewUserService,

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,2 @@
+server:
+  port: "9090"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"gopkg.in/yaml.v3"
+	"os"
+)
+
+type Config struct {
+	Server struct {
+		Port string `yaml:"port"`
+	} `yaml:"server"`
+}
+
+func LoadConfig() (*Config, error) {
+	cfg := &Config{}
+	path := os.Getenv("CONFIG_PATH")
+	if path == "" {
+		path = "config.yaml"
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// default configuration
+		cfg.Server.Port = "8080"
+		return cfg, nil
+	}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+	if cfg.Server.Port == "" {
+		cfg.Server.Port = "8080"
+	}
+	return cfg, nil
+}

--- a/pkg/router/start.go
+++ b/pkg/router/start.go
@@ -2,10 +2,12 @@ package router
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rohitkeshwani07/go-bootstrap/pkg/config"
 	"go.uber.org/fx"
 )
 
@@ -15,9 +17,10 @@ func NewRouter(routes IRoutes) *gin.Engine {
 	return r
 }
 
-func NewHTTPServer(lc fx.Lifecycle, r *gin.Engine) {
+func NewHTTPServer(cfg *config.Config, lc fx.Lifecycle, r *gin.Engine) {
+	addr := fmt.Sprintf(":%s", cfg.Server.Port)
 	srv := &http.Server{
-		Addr:    ":8080",
+		Addr:    addr,
 		Handler: r,
 	}
 

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -1,0 +1,32 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/rohitkeshwani07/go-bootstrap/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadConfigDefault(t *testing.T) {
+	os.Unsetenv("CONFIG_PATH")
+	cfg, err := config.LoadConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, "8080", cfg.Server.Port)
+}
+
+func TestLoadConfigFromFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "config-*.yaml")
+	assert.NoError(t, err)
+	data := []byte("server:\n  port: '1234'\n")
+	_, err = f.Write(data)
+	assert.NoError(t, err)
+	f.Close()
+
+	os.Setenv("CONFIG_PATH", f.Name())
+	defer os.Unsetenv("CONFIG_PATH")
+
+	cfg, err := config.LoadConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, "1234", cfg.Server.Port)
+}


### PR DESCRIPTION
## Summary
- provide a new `config` package to load YAML configuration
- make `NewHTTPServer` use configured port
- wire config loading in `main`
- add example `config.yaml`
- test configuration loading

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68419bad6220832589c25f6135f3eeb1
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add configuration package to load YAML config, update HTTP server to use configured port, and add tests for config loading.
> 
>   - **Configuration**:
>     - Add `config` package with `LoadConfig()` in `pkg/config/config.go` to load YAML configuration.
>     - Default port set to `8080` if no config file is found or port is not specified.
>     - Add example `config.yaml` with port `9090`.
>   - **Server**:
>     - Update `NewHTTPServer()` in `pkg/router/start.go` to use configured port from `Config`.
>     - Wire `LoadConfig()` in `main.go` to provide configuration to the application.
>   - **Testing**:
>     - Add `TestLoadConfigDefault` and `TestLoadConfigFromFile` in `tests/config_test.go` to test configuration loading with and without a config file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=rohitkeshwani07%2Fgo-bootstrap&utm_source=github&utm_medium=referral)<sup> for e87cb51dfa58956266a4585def47cef200ed1cee. You can [customize](https://app.ellipsis.dev/rohitkeshwani07/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->